### PR TITLE
shift click to select rendered tag in element generation window

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -101,7 +101,7 @@ h6 {
 }
 
 .renderedTag {
-  cursor: move;
+  cursor: default;
 }
 
 #elementTree {

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -164,6 +164,14 @@ $(document).ready(function(){
     event.preventDefault();
     chatSubmitHandler();
   });
+
+  // click to select rendered tag from element generation window
+  elementGeneration.on('click','.renderedTag', function (event) {
+    if (event.shiftKey) {
+      let clickedElelement = this.id;
+      selectText(clickedElelement);
+    }
+  });
   // ============= END OF: Utility Event Handlers ============= \\
 
   // ============= Spelling Validation Code ============= \\

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -168,8 +168,8 @@ $(document).ready(function(){
   // click to select rendered tag from element generation window
   elementGeneration.on('click','.renderedTag', function (event) {
     if (event.shiftKey) {
-      let clickedElelement = this.id;
-      selectText(clickedElelement);
+      let clickedElement = this.id;
+      selectText(clickedElement);
     }
   });
   // ============= END OF: Utility Event Handlers ============= \\


### PR DESCRIPTION
Small change overall but it introduces an extra "shift click" feature that allows you to manually select a rendered tag in the element generation window (one that's not already selected) and then since it's selected, it's easily draggable